### PR TITLE
Fixed minor bug with nReads (sometimes) being float

### DIFF
--- a/ChipSeq.py
+++ b/ChipSeq.py
@@ -107,7 +107,7 @@ class ChipSeq:
         duplicates = np.zeros( N, dtype=np.int )
 
         if generateIntervals:
-            readsToDuplicate = np.zeros( nReads, dtype=np.int )
+            readsToDuplicate = np.zeros( int(nReads), dtype=np.int )
         else:
             readsToDuplicate = []
 


### PR DESCRIPTION
It seems that nReads is a float, making Python crash at the following line. This seems to happen when --depth is specified. I simply fixed this by converting nReads to int.